### PR TITLE
Fixes import comment for svcinfo

### DIFF
--- a/svcinfo/svcinfo.go
+++ b/svcinfo/svcinfo.go
@@ -1,4 +1,4 @@
-package svcinfo // import "github.com/dollarshaveclub/go-productionize/svcinfo.go"
+package svcinfo // import "github.com/dollarshaveclub/go-productionize/svcinfo"
 
 import "fmt"
 


### PR DESCRIPTION
- Import comment currently required to get development done with Go
  modules. Fixes the extra ".go" on the end that causes issues when you
  try and "go get" the library