### PR TITLE
Healthz endpoint library

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,114 +6,16 @@ Go Productionize is a set of libraries that can make building a production ready
 
 The service info library stores data that is compiled in at build of the binary.
 
-We currently store the following information about the service:
-
-* Commit SHA
-* Version
-* Build Date
-
-There are currently two ways to add the information:
-* compile time
-* environment variables
-
-### Compile Time
-
-We need to update how we build our binaries to give us the information needed:
-
-```bash
-go build -ldflags '-X github.com/dollarshaveclub/go-productionize/svcinfo.CommitSHA=${SHORT_SHA} -X github.com/dollarshaveclub/go-productionize/svcinfo.Version=${BUILD_VERSION} -X github.com/dollarshaveclub/go-productionize/svcinfo.BuildDate=${BUILD_DATE}'
-```
-
-If dependencies are vendored, you will need to append the import path of the service. For example, if we wanted to set the values for the package `github.com/dollarshaveclub/example` we'd change the above to:
-
-```bash
-go build -ldflags '-X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.CommitSHA=${SHORT_SHA} -X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.Version=${BUILD_VERSION} -X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.BuildDate=${BUILD_DATE}'
-```
-
-### Environment Variables
-
-Add the following environment variables to your Dockerfile with the information you want to used:
-
-* COMMIT_SHA
-* BUILD_DATE
-* VERSION
-
-These values will be automatically pulled at service startup if no values were added at compile time.
-
-### Usage by Services
-
-One helpful way to utilize this information is by adding the information as a set of DataDog tags to every metric. We can do this easily by setting up our DataDog client like the following example:
-
-```go
-func main() {
-    ...
-
-    dd, err := statsd.Client("datadog.addr:8125")
-    if err != nil {
-        // do something with the error
-    }
-    dd.Namespace = "service_name."
-
-    infoTags := svcinfo.GetDDTags()
-    if len(infoTags) > 0 {
-        dd.Tags = append(dd.Tags, infoTags...)
-    }
-
-    ...
-}
-```
-
-We now have the ability to track how stats will change and be able to better understand which version of our service is showing a given issue. It is suggested that you always add the service info DD tags as a default set so that they are added to every metric.
+[Service Info](svcinfo/README.md)
 
 ## Reporter
 
 The reporter library reports different runtime metrics to the DataDog service. This library sends metrics constantly, with a delay of the provided period for each report.
 
-Metrics include:
+[Reporter](reporter/README.md)
 
-* Memory (runtime.MemStats)
-* Runtime
-* Go Information (version, arch, and OS as tags)
-* Service Information (commit, version, and build date as tags)
+## Healthz
 
-### Usage
+Healthz is an HTTP endpoint that provides health information of the application along with some helpful information to the developer such as profiling through pprof. Healthz should be placed on its own HTTP Serve Mux as it contains administrative actions that could be harmful if provided to outside access.
 
-To use the reporter library, you will need to import the library and then run the "New" function inside of the main of your service:
-
-```go
-func main() {
-    ...
-
-    dd, err := statsd.Client("datadog.addr:8125")
-    if err != nil {
-        // do something with the error
-    }
-    dd.Namespace = "service_name."
-
-    r := reporter.New(dd)
-    ...
-}
-```
-
-A reporter is returned and is helpful for usage with other services in this library.
-
-#### Modifying Properties
-
-There are two properties that can be modified:
-
-* Period (how often metrics are sent)
-* Default tags (tags added to every metric reported by reporter)
-
-There are two helper functions that can be used with the "New" method as follows:
-
-```go
-func main() {
-    ...
-
-    r := reporter.New(dd,
-            reporter.Period(10*time.second),
-            reporter.DefaultTags([]string{"tag1:blah", "tag2:blahblah"})
-        )
-
-    ...
-```
+[Healthz](healthz/README.md)

--- a/healthz/README.md
+++ b/healthz/README.md
@@ -1,0 +1,69 @@
+# Healthz
+
+Healthz is an HTTP endpoint that provides health information of the application along with some helpful information to the developer such as profiling through pprof. Healthz should be placed on its own HTTP Serve Mux as it contains administrative actions that could be harmful if provided to outside access.
+
+## Usage
+
+Below is an example for usage of the healthz library.
+
+```go
+func main() {
+  // Create a separate mux because the net/pprof package likes to place things
+  // which we don't want
+  healthMux := &http.ServeMux{}
+
+  // Setup healthz and use the option to set it to be alive right away
+  //
+  // healthz.SetAlive() is an option that can be passed along with others that allow
+  // you to configure different aspects of healthz. Other configuration functions are
+  // available for different configurations and can be chained to the end of the
+  // healthz.New() function.
+  h, err := healthz.New(healthMux, healthz.SetAlive())
+  if err != nil {
+    log.Println(err)
+  }
+
+  // Start healthz on its own port in the background
+  go http.ListenAndServe(":8888", healthMux)
+
+  // Create a separate mux for the actual application to use to prevent leaking
+  // pprof endpoints to the public
+  appMux := &http.ServeMux{}
+
+  // Initialize whatever you need to for your app
+  // ...
+
+  // Once initialized, mark the app as "ready" and start the app
+  h.Ready()
+
+  http.ListenAndServe(":8080", appMux)
+}
+```
+
+### Updating Kubernetes Configuration
+
+Your Kubernetes configuration will need to be updated when adding the Healthz endpoints. You will need to update your `liveliness` and `readiness` configuration to use the new `/healthz` endpoints as well as the port that Healthz is running on.
+
+### Acessing Healthz through Kubernetes
+
+Healthz is place on a different port than what you application will use to accept its traffic. The healthz port will should not be exported to the public since it provides methods for terminating or causing a large amount of work for the application to perform.
+
+So, we will want to use the `kubectl port-forward` command for a specific pod to allow us access as it is required. You will need to pick a Kubernetes pod to use with your port forwarding as well as know the port you want to use.
+
+After the `kubectl port-forward` command is running, you will access the endpoint through your browser using the `localhost` address and the port for Healthz.
+
+### Extensions
+
+You can also add a Reporter along with a DataDog client to extend the information provided back by the `/healthz/stats` endpoint. If these are not provided, there will be fewer stats that are provided back to the user.
+
+## Endpoints
+
+Below is a list of endpoints provided by the healthz library for you to utilize:
+
+* `/healthz/`: List of links to the available endpoints.
+* `/healthz/ready`: Readiness endpoint for usage with Kubernetes. This endpoint is basic as it will be accessed many times a minute.
+* `/healthz/alive`: Liveliness endpoint for usage with Kubernetes. This endpoint is basic as it will be accessed many times a minute.
+* `/healthz/stats`: A set of stats that can be looked up by the user provided by the reporter lib of `go-productoinize`.
+* `/healthz/abortabortabort`: Set the app to unhealthy on the `/healthz/ready` endpoint so that Kubernetes will restart the pod.
+* `/healthz/diediedie`: Will kill the process with an exit code of 255.
+* `/healthz/pprof`: Provides the endpoints provided by the `net/pprof` package. Check that package to see what is available.

--- a/healthz/healthz.go
+++ b/healthz/healthz.go
@@ -1,0 +1,295 @@
+package healthz // import "github.com/dollarshaveclub/go-productionize/healthz"
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/dollarshaveclub/go-productionize/reporter"
+	"github.com/dollarshaveclub/go-productionize/svcinfo"
+)
+
+const (
+	healthy = iota
+	unhealthy
+)
+
+const (
+	rootPrefix = "/healthz"
+
+	indexHTMLTemplate = `
+<html>
+	<head><title>healthz</title></head>
+
+	<body>
+		<h1>Healthz Endpoints</h1>
+		<ul>
+			<li><a href="{{ .Prefix }}/ready">{{ .Prefix }}/ready</a></li>
+			<li><a href="{{ .Prefix }}/alive">{{ .Prefix }}/alive</a></li>
+			<li><a href="{{ .Prefix }}/stats">{{ .Prefix }}/stats</a></li>
+			<li><a href="{{ .Prefix }}/diediedie">{{ .Prefix }}/diediedie</a> (Kills the app)</li>
+			<li><a href="{{ .Prefix }}/abortabortabort">{{ .Prefix }}/abortabortabort</a> (Kills the pod!)</li>
+			<li><a href="{{ .Prefix }}/pprof">{{ .Prefix }}/pprof</a></li>
+		</ul>
+	</body>
+</html>`
+)
+
+var (
+	ready bool
+
+	statuses = []statusInfo{
+		{
+			HTTPCode:    http.StatusOK,
+			Description: "healthy",
+		},
+		{
+			HTTPCode:    http.StatusServiceUnavailable,
+			Description: "unhealthy",
+		},
+	}
+)
+
+type statusInfo struct {
+	HTTPCode    int    `json:"http_code"`
+	Description string `json:"description"`
+}
+
+// Healthz struct
+type Healthz struct {
+	alive  int
+	ready  int
+	Status int
+
+	dd     *statsd.Client
+	ddRate float64
+
+	reporter *reporter.Reporter
+
+	sync.RWMutex
+}
+
+// New will create a new healthz object and setup a new HTTP server mux
+func New(mux *http.ServeMux, opts ...func(*Healthz)) (*Healthz, error) {
+	if mux == nil {
+		return nil, errors.New("you must provide a http.ServeMux")
+	}
+
+	h := &Healthz{
+		alive:  unhealthy,
+		ready:  unhealthy,
+		Status: unhealthy,
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	// path.Join didn't work for the indexHandler here so...
+	mux.HandleFunc(rootPrefix+"/", indexHandler())
+	mux.HandleFunc(path.Join(rootPrefix, "ready"), h.readyHandler())
+	mux.HandleFunc(path.Join(rootPrefix, "alive"), h.livelinessHandler())
+	mux.HandleFunc(path.Join(rootPrefix, "stats"), h.statsHandler())
+
+	mux.HandleFunc(path.Join(rootPrefix, "diediedie"), h.dieDieDieHandler())
+	mux.HandleFunc(path.Join(rootPrefix, "abortabortabort"), h.abortAbortAbortHandler())
+
+	// Add pprof outside of the default HTTP ServeMux
+	mux.HandleFunc(path.Join(rootPrefix, "pprof/"), fakePProfIndexHandler())
+	mux.HandleFunc(path.Join(rootPrefix, "pprof/cmdline"), pprof.Cmdline)
+	mux.HandleFunc(path.Join(rootPrefix, "pprof/profile"), pprof.Profile)
+	mux.HandleFunc(path.Join(rootPrefix, "pprof/symbol"), pprof.Symbol)
+	mux.HandleFunc(path.Join(rootPrefix, "pprof/trace"), pprof.Trace)
+
+	return h, nil
+}
+
+// SetDataDogClient adds the DD client to the healthz endpoints for tracking
+func SetDataDogClient(dd *statsd.Client, rate float64) func(*Healthz) {
+	return func(h *Healthz) {
+		h.dd = dd
+		h.ddRate = rate
+	}
+}
+
+// SetReporter adds an instance of the reporter to get stats about the running app
+func SetReporter(r *reporter.Reporter) func(*Healthz) {
+	return func(h *Healthz) {
+		h.reporter = r
+	}
+}
+
+// SetAlive sets the service to live as soon as the health port is started
+func SetAlive() func(*Healthz) {
+	return func(h *Healthz) {
+		h.alive = healthy
+	}
+}
+
+// indexHandler will provide the user with a basic HTML page that provies access to the available
+// endpoints provided by this library
+func indexHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t, err := template.New("index").Parse(indexHTMLTemplate)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "parsing the HTML template failed: %+v", err)
+		}
+
+		info := struct {
+			Prefix string
+		}{
+			Prefix: rootPrefix,
+		}
+
+		err = t.Execute(w, info)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "error writting index template: %+v", err)
+		}
+	}
+}
+
+// fakePProfIndex will rewrite the path that is sent to the server as the pprof.Index function is
+// hardcoded to expect it to be under "/debug/pprof". So here we strip off the rootPrefix for the
+// healthz endpoint and replace it with "/debug" since we keep the rest under the expected paths
+func fakePProfIndexHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = path.Join("/debug", strings.TrimPrefix(r.URL.Path, rootPrefix))
+		pprof.Index(w, r)
+	}
+}
+
+// Ready will set the readiness endpoint to a good value
+func (h *Healthz) Ready() {
+	h.Lock()
+	h.ready = healthy
+	h.Unlock()
+	return
+}
+
+// NotReady will set the readiness endpoint to report the service as unhealthy
+func (h *Healthz) NotReady() {
+	h.Lock()
+	h.ready = unhealthy
+	h.Unlock()
+	return
+}
+
+// ReadyHandler will be used to handle requests to /healthz/ready
+func (h *Healthz) readyHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		h.RLock()
+		ready := h.ready
+		h.RUnlock()
+
+		if h.dd != nil {
+			defer h.dd.TimeInMilliseconds("healthz.ready", float64(time.Since(start)*time.Millisecond), []string{fmt.Sprintf("ready:%t", ready == healthy)}, h.ddRate)
+		}
+
+		w.WriteHeader(statuses[ready].HTTPCode)
+		fmt.Fprintf(w, statuses[ready].Description)
+	}
+}
+
+// Alive will set the liveliness endpoint to a good value
+func (h *Healthz) Alive() {
+	h.Lock()
+	h.alive = healthy
+	h.Unlock()
+	return
+}
+
+// NotAlive will set the liveliness endpoint to report the service as unhealthy
+func (h *Healthz) NotAlive() {
+	h.Lock()
+	h.alive = unhealthy
+	h.Unlock()
+	return
+}
+
+// LivelinessHandler will be used to handle requests to /healthz/ready
+func (h *Healthz) livelinessHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		h.RLock()
+		alive := h.alive
+		h.RUnlock()
+
+		if h.dd != nil {
+			h.dd.TimeInMilliseconds("healthz.alive", float64(time.Since(start)*time.Millisecond), []string{fmt.Sprintf("alive:%t", alive == healthy)}, h.ddRate)
+		}
+
+		w.WriteHeader(statuses[alive].HTTPCode)
+		fmt.Fprintf(w, statuses[alive].Description)
+	}
+}
+
+func (h *Healthz) statsHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		start := time.Now()
+
+		info := struct {
+			Status    statusInfo            `json:"status"`
+			SvcInfo   svcinfo.ServiceInfo   `json:"service_info"`
+			GoInfo    reporter.GoInfo       `json:"go_info"`
+			GoRuntime reporter.RuntimeStats `json:"runtime"`
+		}{
+			Status: statuses[h.Status],
+		}
+
+		if h.reporter != nil {
+			stats := h.reporter.GetStats()
+			info.GoInfo = stats.GoInfo
+			info.GoRuntime = stats.Runtime
+			info.SvcInfo = stats.ServiceInfo
+		}
+
+		if h.dd != nil {
+			defer h.dd.TimeInMilliseconds("healthz.stats", float64(time.Since(start)*time.Millisecond), []string{fmt.Sprintf("error:%t", err != nil)}, h.ddRate)
+		}
+
+		infoJSON, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "error getting stats: %v", err)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(infoJSON)
+	}
+}
+
+// dieDieDieHandler will quickly terminate the server
+func (h *Healthz) dieDieDieHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		os.Exit(255)
+	}
+}
+
+// abortAbortAbortHandler will set the ready and alive endpoints to report unhealthy so that
+// k8s will take care of it
+func (h *Healthz) abortAbortAbortHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h.NotReady()
+		h.NotAlive()
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "App reporting as unhealthy...")
+	}
+}

--- a/reporter/README.md
+++ b/reporter/README.md
@@ -1,0 +1,51 @@
+# Reporter 
+The reporter library reports different runtime metrics to the DataDog service. This library sends metrics constantly, with a delay of the provided period for each report.
+
+Metrics include:
+
+* Memory (runtime.MemStats)
+* Runtime
+* Go Information (version, arch, and OS as tags)
+* Service Information (commit, version, and build date as tags)
+
+## Usage
+
+To use the reporter library, you will need to import the library and then run the "New" function inside of the main of your service:
+
+```go
+func main() {
+    ...
+
+    dd, err := statsd.Client("datadog.addr:8125")
+    if err != nil {
+        // do something with the error
+    }
+    dd.Namespace = "service_name."
+
+    r := reporter.New(dd)
+    ...
+}
+```
+
+A reporter is returned and is helpful for usage with other services in this library.
+
+### Modifying Properties
+
+There are two properties that can be modified:
+
+* Period (how often metrics are sent)
+* Default tags (tags added to every metric reported by reporter)
+
+There are two helper functions that can be used with the "New" method as follows:
+
+```go
+func main() {
+    ...
+
+    r := reporter.New(dd,
+            reporter.Period(10*time.second),
+            reporter.DefaultTags([]string{"tag1:blah", "tag2:blahblah"})
+        )
+
+    ...
+```

--- a/svcinfo/README.md
+++ b/svcinfo/README.md
@@ -1,0 +1,62 @@
+# Service Info (svcinfo)
+
+The service info library stores data that is compiled in at build of the binary.
+
+We currently store the following information about the service:
+
+* Commit SHA
+* Version
+* Build Date
+
+There are currently two ways to add the information:
+* compile time
+* environment variables
+
+## Compile Time
+
+We need to update how we build our binaries to give us the information needed:
+
+```bash
+go build -ldflags '-X github.com/dollarshaveclub/go-productionize/svcinfo.CommitSHA=${SHORT_SHA} -X github.com/dollarshaveclub/go-productionize/svcinfo.Version=${BUILD_VERSION} -X github.com/dollarshaveclub/go-productionize/svcinfo.BuildDate=${BUILD_DATE}'
+```
+
+If dependencies are vendored, you will need to append the import path of the service. For example, if we wanted to set the values for the package `github.com/dollarshaveclub/example` we'd change the above to:
+
+```bash
+go build -ldflags '-X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.CommitSHA=${SHORT_SHA} -X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.Version=${BUILD_VERSION} -X github.com/dollarshaveclub/example/vendor/github.com/dollarshaveclub/go-productionize/svcinfo.BuildDate=${BUILD_DATE}'
+```
+
+## Environment Variables
+
+Add the following environment variables to your Dockerfile with the information you want to used:
+
+* COMMIT_SHA
+* BUILD_DATE
+* VERSION
+
+These values will be automatically pulled at service startup if no values were added at compile time.
+
+## Usage by Services
+
+One helpful way to utilize this information is by adding the information as a set of DataDog tags to every metric. We can do this easily by setting up our DataDog client like the following example:
+
+```go
+func main() {
+    ...
+
+    dd, err := statsd.Client("datadog.addr:8125")
+    if err != nil {
+        // do something with the error
+    }
+    dd.Namespace = "service_name."
+
+    infoTags := svcinfo.GetDDTags()
+    if len(infoTags) > 0 {
+        dd.Tags = append(dd.Tags, infoTags...)
+    }
+
+    ...
+}
+```
+
+We now have the ability to track how stats will change and be able to better understand which version of our service is showing a given issue. It is suggested that you always add the service info DD tags as a default set so that they are added to every metric.


### PR DESCRIPTION
Healthz is a set of endpoints that provides extra fuctionality for the
application to work with a a scheduler as well as to provide additional
information back to the developers of the application though profiling
systems such as pprof. Healthz attempts to provide extended
functionality for operating the application through both information as
well as direct control.

- Adds endpoint for liveliness along with functions to toggle liveliness
  status of the application using a set of provided functions
- Adds endpoint for readiness along with functions to toggle the
  readiness status of the application using a set of provided functions
- Adds endpoints to terminate the application either through the
  scheduler or by the application directly
- Adds the net/pprof endpoints underneath the the /healthz prefix
- Adds support for reporting reporter provided metrics to the developer
  through a web interface
- Adds support for tracking access to the healthz endpoints through
  DataDog metrics